### PR TITLE
Update xrefs

### DIFF
--- a/lightspeed/modules/con_config-custom-models.adoc
+++ b/lightspeed/modules/con_config-custom-models.adoc
@@ -4,7 +4,6 @@
 
 = Configuring custom models
 
-:context: configure-custom-models
 
 As an organization administrator, you can create and use fine-tuned, custom models that are trained on your organization's existing Ansible content. With this capability, you can tune the models to your organization's automation patterns and improve the code recommendation experience.
 

--- a/lightspeed/modules/con_config-vs-code-extension.adoc
+++ b/lightspeed/modules/con_config-vs-code-extension.adoc
@@ -4,7 +4,6 @@
 
 = Installing and configuring the Ansible VS Code extension
 
-:context: con-configure-vs-code-extension
 
 {LightspeedFullName} is integrated with the Ansible Visual Studio (VS) Code extension in VS Code. The Ansible VS Code extension, with {LightspeedShortName} features enabled, automatically collects recommendations, usage telemetry, and Ansible YAML file state through automated events. 
 

--- a/lightspeed/modules/con_log-into-portal-auto-dev.adoc
+++ b/lightspeed/modules/con_log-into-portal-auto-dev.adoc
@@ -4,7 +4,6 @@
 
 = Accessing the Ansible Lightspeed portal as an automation developer
 
-:context: log-into-portal-auto-dev
 
 You can access {LightspeedShortName} through the link:https://c.ai.ansible.redhat.com/[Ansible Lightspeed portal]. After you enter your {RHSSO} ({RHSSOshort}) account credentials, your account is authenticated and you are granted access. Your assigned user role is displayed on the login screen of the Ansible Lightspeed portal. 
 

--- a/lightspeed/modules/con_view-manage-admin-dashboard-telemetry.adoc
+++ b/lightspeed/modules/con_view-manage-admin-dashboard-telemetry.adoc
@@ -4,7 +4,6 @@
 
 = Viewing and managing the Admin dashboard telemetry
 
-:context: view-manage-admin-dashboard-telemetry
 
 {LightspeedshortName} collects the following telemetry data by default:
 

--- a/lightspeed/modules/proc_configure-vscode-extension-onpremise-deployment.adoc
+++ b/lightspeed/modules/proc_configure-vscode-extension-onpremise-deployment.adoc
@@ -20,7 +20,7 @@ To access the on-premise deployment of {LightspeedShortName}, all Ansible users 
 * In the *URL for Ansible Lightspeed* field, enter the *Route URL* of the {LightspeedShortName} on-premise deployment. Ansible users must have {PlatformNameShort} controller credentials. 
 * Optional: If you want to use a custom model instead of the default model, in the *Model ID Override* field, enter the custom model ID. Your settings are automatically saved in VS Code.
 +
-After configuring Ansible VS Code extension to connect to {LightspeedShortName} on-premise deployment, you must xref:login-vscode-extension_configuring-with-code-assistant[log in to Ansible Lightspeed through the Ansible VS Code extension]. 
+After configuring Ansible VS Code extension to connect to {LightspeedShortName} on-premise deployment, you must xref:login-vscode-extension_developing-ansible-content[log in to Ansible Lightspeed through the Ansible VS Code extension]. 
 +
 [NOTE]
 ====

--- a/lightspeed/modules/proc_log-into-portal-auto-dev.adoc
+++ b/lightspeed/modules/proc_log-into-portal-auto-dev.adoc
@@ -4,7 +4,6 @@
 
 = Logging in to the Ansible Lightspeed portal as an automation developer
 
-:context: con-configure-vs-code-extension
 
 .Procedure
 

--- a/lightspeed/modules/proc_start-lightspeed-trial.adoc
+++ b/lightspeed/modules/proc_start-lightspeed-trial.adoc
@@ -10,7 +10,7 @@
 .Procedure
 . Open the VS Code application.
 . From the VS Code activity bar, click the *Ansible* icon to open the left panel.
-. Ensure that you have configured the Ansible VS Code extension to enable {LightspeedShortName}. For the steps, see xref:con-configure-vscode-extension_developing-ansible-content[Configuring the Ansible VS Code extension].
+. Ensure that you have configured the Ansible VS Code extension to enable {LightspeedShortName}. For the steps, see xref:configure-vscode-extension_developing-ansible-content[Configuring the Ansible VS Code extension].
 . In the *Ansible Lightspeed* view, click *Connect*.
 . Enter your Red Hat account username and password. 
 . In the Ansible Lightspeed view, click *Start trial*. The link:https://c.ai.ansible.redhat.com/[Ansible Lightspeed portal login page] opens. 

--- a/lightspeed/modules/proc_troubleshooting-vscode.adoc
+++ b/lightspeed/modules/proc_troubleshooting-vscode.adoc
@@ -18,7 +18,7 @@ To resolve this error, ensure that:
 *** Your organization has a trial or paid subscription to the {PlatformName}, and you have a {LightspeedShortName} trial account.
 
 * You have not configured the required Ansible VS code extension settings.
-** To resolve this error, ensure that you have enabled the *Lightspeed:Enabled* and menu:Lightspeed[Suggestions:Enabled] settings. For more information, see xref:configure-vscode-extension_configuring-with-code-assistant[Configure the Ansible VS Code extension].
+** To resolve this error, ensure that you have enabled the *Lightspeed:Enabled* and menu:Lightspeed[Suggestions:Enabled] settings. For more information, see xref:configure-vscode-extension_developing-ansible-content[Configure the Ansible VS Code extension].
 
 * You receive a `Failure on completion requests` error when you make inference requests in VS Code.
 +


### PR DESCRIPTION
@sayjadha 
The xrefs are working except for these two:

`Unknown ID or title "manually-scan-repo_using-code-bot-for-suggestions", used as an internal cross reference`
* Referenced from `proc_troubleshooting-code-bot.adoc` and  `./proc_install-code-bot.adoc`
* Target is `./modules/proc_manually-scan-repo.adoc` but this module isn't included in the doc

`Unknown ID or title "ansible-code-bot-duplicate-pr", used as an internal cross reference`
* Referenced in `proc_troubleshooting-code-bot.adoc`
* Target is `assembly_using-code-bot-for-suggestions.adoc`  but this assembly is not included in the doc